### PR TITLE
fix build error in MSVC build

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -791,7 +791,7 @@ template <> struct DenseMapInfo<BasicBlock::iterator> {
   static unsigned getHashValue(const BasicBlock::iterator &It) {
     return DenseMapInfo<void *>::getHashValue(
                reinterpret_cast<void *>(It.getNodePtr())) ^
-           It.getHeadBit();
+           (int) It.getHeadBit();
   }
 
   static bool isEqual(const BasicBlock::iterator &LHS,


### PR DESCRIPTION
This commit(https://github.com/llvm/llvm-project/pull/84738) introduced following compile warning then treated-as-error in MSVC build.

>>>"'^': unsafe mix of type 'unsigned int' and type 'bool' in operation"